### PR TITLE
Feature/9 로그인 정보로 데이터 조회/추가 처리

### DIFF
--- a/src/app/detail/[id]/page.tsx
+++ b/src/app/detail/[id]/page.tsx
@@ -4,5 +4,5 @@ import Layout from '../../../components/detailLayout';
 import {usePath} from '../../../lib/utils';
 
 export default function Home() {
-  return <Layout id={usePath()}></Layout>;
+  return <Layout swimmingpool_id={usePath()}></Layout>;
 }

--- a/src/components/detailLayout.tsx
+++ b/src/components/detailLayout.tsx
@@ -9,18 +9,22 @@ import ErrorPage from './error';
 import {fetchReviewData} from '@/data/firestore';
 import {PublicSwimmingPool, ReviewData} from '../lib/types';
 
-export default function Layout({id}: {readonly id: string}) {
+export default function Layout({
+  swimmingpool_id,
+}: {
+  readonly swimmingpool_id: string;
+}) {
   const {data, loading, error} = useData();
   const [reviews, setReviews] = useState<ReviewData[]>([]);
 
   useEffect(() => {
     const fetchData = async () => {
-      const reviews = await fetchReviewData(id);
+      const reviews = await fetchReviewData(swimmingpool_id);
       setReviews(reviews);
     };
 
     fetchData();
-  }, [id]);
+  }, [swimmingpool_id]);
 
   function SwimmingPoolDetail({item}: {item: PublicSwimmingPool}) {
     return (
@@ -59,11 +63,13 @@ export default function Layout({id}: {readonly id: string}) {
             className="flex w-full mx-auto mb-5 flex-wrap bg-white rounded-lg overflow-hidden shadow-md p-4"
           >
             <p className="title-font text-gray-900 lg:w-3/4 lg:mb-0 mb-4">
-              {item.contents}
+              {item.review_content}
             </p>
             <div className="flex-grow"></div>
             <div className="flex justify-between">
-              <p className="text-gray-900 text-sm mr-5">{item.user}</p>
+              <p className="text-gray-900 text-sm mr-5">
+                {item.author_user_id}
+              </p>
               <p className="text-gray-500 text-sm">{item.reg_date}</p>
             </div>
           </div>
@@ -86,7 +92,7 @@ export default function Layout({id}: {readonly id: string}) {
       <section className="text-gray-600 body-font overflow-hidden min-h-max">
         {data.map((item, index) => (
           <div key={index}>
-            {item.id === id && (
+            {item.id === swimmingpool_id && (
               <div className="container px-5 mx-auto max-w-screen-xl">
                 <SwimmingPoolDetail item={item} />
                 <ReviewList reviews={reviews} />

--- a/src/components/detailLayout.tsx
+++ b/src/components/detailLayout.tsx
@@ -6,7 +6,7 @@ import {useState, useEffect} from 'react';
 import useData from '../lib/requestdata';
 import Loading from './loading';
 import ErrorPage from './error';
-import {fetchReviewData} from '@/data/firestore';
+import {fetchReviewsBySwimmingPoolId} from '@/data/firestore';
 import {PublicSwimmingPool, ReviewData} from '../lib/types';
 
 function SwimmingPoolDetail({item}: {item: PublicSwimmingPool}) {
@@ -72,7 +72,7 @@ export default function Layout({
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const reviews = await fetchReviewData(swimmingpool_id);
+        const reviews = await fetchReviewsBySwimmingPoolId(swimmingpool_id);
 
         if (reviews) {
           setReviews(reviews);

--- a/src/components/detailLayout.tsx
+++ b/src/components/detailLayout.tsx
@@ -50,7 +50,9 @@ function ReviewList({reviews}: {reviews: ReviewData[]}) {
           </p>
           <div className="flex-grow"></div>
           <div className="flex justify-between">
-            <p className="text-gray-900 text-sm mr-5">{item.author_user_id}</p>
+            <p className="text-gray-900 text-sm mr-5">
+              {item.author_user_name}
+            </p>
             <p className="text-gray-500 text-sm">{item.reg_date}</p>
           </div>
         </div>

--- a/src/components/detailLayout.tsx
+++ b/src/components/detailLayout.tsx
@@ -9,6 +9,56 @@ import ErrorPage from './error';
 import {fetchReviewData} from '@/data/firestore';
 import {PublicSwimmingPool, ReviewData} from '../lib/types';
 
+function SwimmingPoolDetail({item}: {item: PublicSwimmingPool}) {
+  return (
+    <div className="py-8 flex flex-wrap md:flex-nowrap">
+      <div className="md:w-64 mr-10 md:mb-0 mb-6 flex-shrink-0 flex flex-col">
+        <img src="https://dummyimage.com/720x600" alt="Placeholder Image" />
+      </div>
+      <div className="md:flex-grow mt-10">
+        <h2 className="text-2xl font-medium text-gray-900 title-font mb-20">
+          {item.FACLT_NM}
+        </h2>
+        <p className="leading-relaxed">{item.SIGUN_NM}</p>
+        <p className="leading-relaxed">{item.CONTCT_NO}</p>
+        <p className="leading-relaxed">{item.HMPG_ADDR}</p>
+        {(item.IRREGULR_RELYSWIMPL_LENG &&
+          item.IRREGULR_RELYSWIMPL_LANE_CNT) !== null && (
+          <p className="leading-relaxed">
+            {item.IRREGULR_RELYSWIMPL_LENG}m *{' '}
+            {item.IRREGULR_RELYSWIMPL_LANE_CNT}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ReviewList({reviews}: {reviews: ReviewData[]}) {
+  return (
+    <div className="md:flex-grow mt-20">
+      <p className="text-2xl font-medium text-gray-900 title-font mb-7">
+        수영장 리뷰
+      </p>
+      {reviews.map((item, index) => (
+        <div
+          key={index}
+          className="flex w-full mx-auto mb-5 flex-wrap bg-white rounded-lg overflow-hidden shadow-md p-4"
+        >
+          <p className="title-font text-gray-900 lg:w-3/4 lg:mb-0 mb-4">
+            {item.review_content}
+          </p>
+          <div className="flex-grow"></div>
+          <div className="flex justify-between">
+            <p className="text-gray-900 text-sm mr-5">{item.author_user_id}</p>
+            <p className="text-gray-500 text-sm">{item.reg_date}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export default function Layout({
   swimmingpool_id,
 }: {
@@ -38,58 +88,6 @@ export default function Layout({
       console.error('Invalid swimmingpool_id:', swimmingpool_id);
     }
   }, [swimmingpool_id]);
-
-  function SwimmingPoolDetail({item}: {item: PublicSwimmingPool}) {
-    return (
-      <div className="py-8 flex flex-wrap md:flex-nowrap">
-        <div className="md:w-64 mr-10 md:mb-0 mb-6 flex-shrink-0 flex flex-col">
-          <img src="https://dummyimage.com/720x600" alt="Placeholder Image" />
-        </div>
-        <div className="md:flex-grow mt-10">
-          <h2 className="text-2xl font-medium text-gray-900 title-font mb-20">
-            {item.FACLT_NM}
-          </h2>
-          <p className="leading-relaxed">{item.SIGUN_NM}</p>
-          <p className="leading-relaxed">{item.CONTCT_NO}</p>
-          <p className="leading-relaxed">{item.HMPG_ADDR}</p>
-          {(item.IRREGULR_RELYSWIMPL_LENG &&
-            item.IRREGULR_RELYSWIMPL_LANE_CNT) !== null && (
-            <p className="leading-relaxed">
-              {item.IRREGULR_RELYSWIMPL_LENG}m *{' '}
-              {item.IRREGULR_RELYSWIMPL_LANE_CNT}
-            </p>
-          )}
-        </div>
-      </div>
-    );
-  }
-
-  function ReviewList({reviews}: {reviews: ReviewData[]}) {
-    return (
-      <div className="md:flex-grow mt-20">
-        <p className="text-2xl font-medium text-gray-900 title-font mb-7">
-          수영장 리뷰
-        </p>
-        {reviews.map((item, index) => (
-          <div
-            key={index}
-            className="flex w-full mx-auto mb-5 flex-wrap bg-white rounded-lg overflow-hidden shadow-md p-4"
-          >
-            <p className="title-font text-gray-900 lg:w-3/4 lg:mb-0 mb-4">
-              {item.review_content}
-            </p>
-            <div className="flex-grow"></div>
-            <div className="flex justify-between">
-              <p className="text-gray-900 text-sm mr-5">
-                {item.author_user_id}
-              </p>
-              <p className="text-gray-500 text-sm">{item.reg_date}</p>
-            </div>
-          </div>
-        ))}
-      </div>
-    );
-  }
 
   if (loading) {
     return <Loading />;

--- a/src/components/detailLayout.tsx
+++ b/src/components/detailLayout.tsx
@@ -7,16 +7,7 @@ import useData from '../lib/requestdata';
 import Loading from './loading';
 import ErrorPage from './error';
 import {fetchReviewData} from '@/data/firestore';
-import {PublicSwimmingPool} from '../lib/types';
-
-interface ReviewData {
-  id: string;
-  address: string;
-  contents: string;
-  name: string;
-  user: string;
-  reg_date: string;
-}
+import {PublicSwimmingPool, ReviewData} from '../lib/types';
 
 export default function Layout({id}: {readonly id: string}) {
   const {data, loading, error} = useData();

--- a/src/components/detailLayout.tsx
+++ b/src/components/detailLayout.tsx
@@ -19,11 +19,24 @@ export default function Layout({
 
   useEffect(() => {
     const fetchData = async () => {
-      const reviews = await fetchReviewData(swimmingpool_id);
-      setReviews(reviews);
+      try {
+        const reviews = await fetchReviewData(swimmingpool_id);
+
+        if (reviews) {
+          setReviews(reviews);
+        } else {
+          console.error('Fetch reviews returned undefined');
+        }
+      } catch (error) {
+        console.error('Error fetching reviews:', error);
+      }
     };
 
-    fetchData();
+    if (swimmingpool_id) {
+      fetchData();
+    } else {
+      console.error('Invalid swimmingpool_id:', swimmingpool_id);
+    }
   }, [swimmingpool_id]);
 
   function SwimmingPoolDetail({item}: {item: PublicSwimmingPool}) {

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import {singOut} from '../data/firestore';
 import {useAuthState} from '../contexts/AuthContext';
-import {AuthContextType} from '../lib/types';
+import {User} from 'firebase/auth';
 
 export default function Header() {
   const user = useAuthState();
@@ -10,31 +10,54 @@ export default function Header() {
     singOut();
   };
 
-  const AuthenticatedUserControls = ({
-    user,
-    href,
-  }: {
-    user: AuthContextType;
-    href: string;
-  }) => (
-    <Link href={href} className="mr-3">
-      <button className="inline-flex items-center bg-gray-100 border-0 py-1 px-3 focus:outline-none hover:bg-gray-200 rounded text-base mt-4 md:mt-0 text-blue-500">
-        {user.displayName !== null && `${user.displayName}님`}
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          className="size-8"
-        >
-          <path
-            className="stroke-2"
-            d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
-          />
-        </svg>
-      </button>
-    </Link>
-  );
+  const AuthenticatedUserControls = ({user}: {user: User | null}) => {
+    return (
+      <div>
+        {user ? (
+          <Link href={'/mypage'} className="mr-3">
+            <button className="inline-flex items-center bg-gray-100 border-0 py-1 px-3 focus:outline-none hover:bg-gray-200 rounded text-base mt-4 md:mt-0 text-blue-500">
+              {`${user.email?.split('@')[0]}님`}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                className="size-8"
+              >
+                <path
+                  className="stroke-2"
+                  d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+                />
+              </svg>
+            </button>
+            <button
+              className="text-gray-300 text-sm mt-5 hover:text-gray-500"
+              onClick={handleClick}
+            >
+              로그아웃
+            </button>
+          </Link>
+        ) : (
+          <Link href={'/login'} className="mr-3">
+            <button className="inline-flex items-center bg-gray-100 border-0 py-1 px-3 focus:outline-none hover:bg-gray-200 rounded text-base mt-4 md:mt-0 text-blue-500">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                className="size-8"
+              >
+                <path
+                  className="stroke-2"
+                  d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+                />
+              </svg>
+            </button>
+          </Link>
+        )}
+      </div>
+    );
+  };
 
   return (
     <>
@@ -63,19 +86,7 @@ export default function Header() {
             </span>
           </Link>
           <nav className="md:ml-auto flex flex-wrap items-center text-base justify-center">
-            {user.displayName !== null ? (
-              <>
-                <AuthenticatedUserControls user={user} href={'/mypage'} />
-                <button
-                  className="text-gray-300 text-sm mt-5 hover:text-gray-500"
-                  onClick={handleClick}
-                >
-                  로그아웃
-                </button>
-              </>
-            ) : (
-              <AuthenticatedUserControls user={user} href={'/login'} />
-            )}
+            <AuthenticatedUserControls user={user} />
           </nav>
         </div>
       </header>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -2,62 +2,68 @@ import Link from 'next/link';
 import {singOut} from '../data/firestore';
 import {useAuthState} from '../contexts/AuthContext';
 import {User} from 'firebase/auth';
+import {useRouter} from 'next/navigation';
+
+const WithAuthenticatedUserControls = ({user}: {user: User | null}) => {
+  const router = useRouter();
+
+  const handleClick = async () => {
+    await singOut();
+    router.push('/');
+  };
+
+  return (
+    <div>
+      <Link href={'/mypage'} className="mr-3">
+        <button className="inline-flex items-center bg-gray-100 border-0 py-1 px-3 focus:outline-none hover:bg-gray-200 rounded text-base mt-4 md:mt-0 text-blue-500">
+          {`${user?.displayName}님`}
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            className="size-8"
+          >
+            <path
+              className="stroke-2"
+              d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+            />
+          </svg>
+        </button>
+      </Link>
+      <button
+        className="text-gray-300 text-sm mt-5 hover:text-gray-500"
+        onClick={handleClick}
+      >
+        로그아웃
+      </button>
+    </div>
+  );
+};
+
+const WithoutAuthenticatedUser = () => {
+  return (
+    <Link href={'/login'} className="mr-3">
+      <button className="inline-flex items-center bg-gray-100 border-0 py-1 px-3 focus:outline-none hover:bg-gray-200 rounded text-base mt-4 md:mt-0 text-blue-500">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          className="size-8"
+        >
+          <path
+            className="stroke-2"
+            d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+          />
+        </svg>
+      </button>
+    </Link>
+  );
+};
 
 export default function Header() {
   const user = useAuthState();
-
-  const handleClick = () => {
-    singOut();
-  };
-
-  const AuthenticatedUserControls = ({user}: {user: User | null}) => {
-    return (
-      <div>
-        {user ? (
-          <Link href={'/mypage'} className="mr-3">
-            <button className="inline-flex items-center bg-gray-100 border-0 py-1 px-3 focus:outline-none hover:bg-gray-200 rounded text-base mt-4 md:mt-0 text-blue-500">
-              {`${user.email?.split('@')[0]}님`}
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                className="size-8"
-              >
-                <path
-                  className="stroke-2"
-                  d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
-                />
-              </svg>
-            </button>
-            <button
-              className="text-gray-300 text-sm mt-5 hover:text-gray-500"
-              onClick={handleClick}
-            >
-              로그아웃
-            </button>
-          </Link>
-        ) : (
-          <Link href={'/login'} className="mr-3">
-            <button className="inline-flex items-center bg-gray-100 border-0 py-1 px-3 focus:outline-none hover:bg-gray-200 rounded text-base mt-4 md:mt-0 text-blue-500">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                className="size-8"
-              >
-                <path
-                  className="stroke-2"
-                  d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
-                />
-              </svg>
-            </button>
-          </Link>
-        )}
-      </div>
-    );
-  };
 
   return (
     <>
@@ -86,7 +92,11 @@ export default function Header() {
             </span>
           </Link>
           <nav className="md:ml-auto flex flex-wrap items-center text-base justify-center">
-            <AuthenticatedUserControls user={user} />
+            {user ? (
+              <WithAuthenticatedUserControls user={user} />
+            ) : (
+              <WithoutAuthenticatedUser />
+            )}
           </nav>
         </div>
       </header>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import {singOut} from '../data/firestore';
 import {useAuthState} from '../contexts/AuthContext';
+import {AuthContextType} from '../lib/types';
 
 export default function Header() {
   const user = useAuthState();
@@ -8,6 +9,34 @@ export default function Header() {
   const handleClick = () => {
     singOut();
   };
+
+  const AuthenticatedUserControls = ({
+    user,
+    href,
+  }: {
+    user: AuthContextType;
+    href: string;
+  }) => (
+    <>
+      <Link href={href} className="mr-3">
+        <button className="inline-flex items-center bg-gray-100 border-0 py-1 px-3 focus:outline-none hover:bg-gray-200 rounded text-base mt-4 md:mt-0 text-blue-500">
+          {user.displayName !== null && `${user.displayName}님`}
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            className="size-8"
+          >
+            <path
+              className="stroke-2"
+              d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+            />
+          </svg>
+        </button>
+      </Link>
+    </>
+  );
 
   return (
     <>
@@ -36,26 +65,9 @@ export default function Header() {
             </span>
           </Link>
           <nav className="md:ml-auto flex flex-wrap items-center text-base justify-center">
-            {/* 중복 코드 존재 -> 정리 필요 */}
             {user.displayName !== null ? (
               <>
-                <Link href={'/mypage'} className="mr-3">
-                  <button className="inline-flex items-center bg-gray-100 border-0 py-1 px-3 focus:outline-none hover:bg-gray-200 rounded text-base mt-4 md:mt-0 text-blue-500">
-                    {user.displayName}님
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      className="size-8 ml-2"
-                    >
-                      <path
-                        className="stroke-2"
-                        d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
-                      />
-                    </svg>
-                  </button>
-                </Link>
+                <AuthenticatedUserControls user={user} href={'/mypage'} />
                 <button
                   className="text-gray-300 text-sm mt-5 hover:text-gray-500"
                   onClick={handleClick}
@@ -64,22 +76,7 @@ export default function Header() {
                 </button>
               </>
             ) : (
-              <Link href={'/login'}>
-                <button className="inline-flex items-center bg-gray-100 border-0 py-1 px-3 focus:outline-none hover:bg-gray-200 rounded text-base mt-4 md:mt-0 text-blue-500">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    className="size-8"
-                  >
-                    <path
-                      className="stroke-2"
-                      d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
-                    />
-                  </svg>
-                </button>
-              </Link>
+              <AuthenticatedUserControls user={user} href={'/login'} />
             )}
           </nav>
         </div>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -17,25 +17,23 @@ export default function Header() {
     user: AuthContextType;
     href: string;
   }) => (
-    <>
-      <Link href={href} className="mr-3">
-        <button className="inline-flex items-center bg-gray-100 border-0 py-1 px-3 focus:outline-none hover:bg-gray-200 rounded text-base mt-4 md:mt-0 text-blue-500">
-          {user.displayName !== null && `${user.displayName}님`}
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            className="size-8"
-          >
-            <path
-              className="stroke-2"
-              d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
-            />
-          </svg>
-        </button>
-      </Link>
-    </>
+    <Link href={href} className="mr-3">
+      <button className="inline-flex items-center bg-gray-100 border-0 py-1 px-3 focus:outline-none hover:bg-gray-200 rounded text-base mt-4 md:mt-0 text-blue-500">
+        {user.displayName !== null && `${user.displayName}님`}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          className="size-8"
+        >
+          <path
+            className="stroke-2"
+            d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+          />
+        </svg>
+      </button>
+    </Link>
   );
 
   return (

--- a/src/components/mypage.tsx
+++ b/src/components/mypage.tsx
@@ -41,7 +41,7 @@ export default function Layout({children}: {children: React.ReactNode}) {
 
         if (reviews) {
           const filteredReviews = reviews.filter(
-            review => review.author_user_id === user.displayName,
+            review => review.author_user_id === user?.uid,
           );
           setReviews(filteredReviews);
         } else {
@@ -53,7 +53,7 @@ export default function Layout({children}: {children: React.ReactNode}) {
     };
 
     fetchData();
-  }, [user.displayName]);
+  }, [user?.uid]);
 
   return (
     <>

--- a/src/components/mypage.tsx
+++ b/src/components/mypage.tsx
@@ -3,10 +3,10 @@ import Footer from './footer';
 import Link from 'next/link';
 import {useEffect, useState} from 'react';
 import {useAuthState} from '../contexts/AuthContext';
-import {ReviewData} from '../lib/types';
-import {fetchReviewData} from '@/data/firestore';
+import {TotalData} from '../lib/types';
+import {fetchReviewByUserId} from '@/data/firestore';
 
-function ReviewList({reviews}: {reviews: ReviewData[]}) {
+function ReviewList({reviews}: {reviews: TotalData[]}) {
   return (
     <div className="md:flex-grow mt-20">
       {reviews.map((item, index) => (
@@ -31,27 +31,20 @@ function ReviewList({reviews}: {reviews: ReviewData[]}) {
 }
 
 export default function Layout({children}: {children: React.ReactNode}) {
-  const [reviews, setReviews] = useState<ReviewData[]>([]);
+  const [reviews, setReviews] = useState<TotalData[]>([]);
   const user = useAuthState();
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const reviews = await fetchReviewData();
-
-        if (reviews) {
-          const filteredReviews = reviews.filter(
-            review => review.author_user_id === user?.uid,
-          );
-          setReviews(filteredReviews);
-        } else {
-          console.error('Fetch reviews returned undefined');
+        if (user?.uid) {
+          const reviews = await fetchReviewByUserId(user.uid);
+          setReviews(reviews);
         }
       } catch (error) {
         console.error('Error fetching reviews:', error);
       }
     };
-
     fetchData();
   }, [user?.uid]);
 

--- a/src/components/mypage.tsx
+++ b/src/components/mypage.tsx
@@ -15,7 +15,7 @@ export default function Layout({children}: {children: React.ReactNode}) {
       const reviews = await fetchReviewData();
 
       const filteredReviews = reviews.filter(
-        review => review.user === user.displayName,
+        review => review.author_user_id === user.displayName,
       );
 
       setReviews(filteredReviews);
@@ -33,10 +33,10 @@ export default function Layout({children}: {children: React.ReactNode}) {
             className="flex w-full mx-auto mb-5 flex-wrap bg-white rounded-lg overflow-hidden shadow-md p-4"
           >
             <p className="title-font text-gray-900 lg:w-3/4 lg:mb-0 mb-4 font-bold">
-              {item.name}
+              {item.swimmingpool_name}
             </p>
             <p className="title-font text-gray-900 lg:w-3/4 lg:mb-0 mb-4">
-              {item.contents}
+              {item.review_content}
             </p>
             <div className="flex-grow"></div>
             <div className="flex justify-between">

--- a/src/components/mypage.tsx
+++ b/src/components/mypage.tsx
@@ -6,6 +6,30 @@ import {useAuthState} from '../contexts/AuthContext';
 import {ReviewData} from '../lib/types';
 import {fetchReviewData} from '@/data/firestore';
 
+function ReviewList({reviews}: {reviews: ReviewData[]}) {
+  return (
+    <div className="md:flex-grow mt-20">
+      {reviews.map((item, index) => (
+        <div
+          key={index}
+          className="flex w-full mx-auto mb-5 flex-wrap bg-white rounded-lg overflow-hidden shadow-md p-4"
+        >
+          <p className="title-font text-gray-900 lg:w-3/4 lg:mb-0 mb-4 font-bold">
+            {item.swimmingpool_name}
+          </p>
+          <p className="title-font text-gray-900 lg:w-3/4 lg:mb-0 mb-4">
+            {item.review_content}
+          </p>
+          <div className="flex-grow"></div>
+          <div className="flex justify-between">
+            <p className="text-gray-500 text-sm">{item.reg_date}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export default function Layout({children}: {children: React.ReactNode}) {
   const [reviews, setReviews] = useState<ReviewData[]>([]);
   const user = useAuthState();
@@ -30,30 +54,6 @@ export default function Layout({children}: {children: React.ReactNode}) {
 
     fetchData();
   }, [user.displayName]);
-
-  function ReviewList({reviews}: {reviews: ReviewData[]}) {
-    return (
-      <div className="md:flex-grow mt-20">
-        {reviews.map((item, index) => (
-          <div
-            key={index}
-            className="flex w-full mx-auto mb-5 flex-wrap bg-white rounded-lg overflow-hidden shadow-md p-4"
-          >
-            <p className="title-font text-gray-900 lg:w-3/4 lg:mb-0 mb-4 font-bold">
-              {item.swimmingpool_name}
-            </p>
-            <p className="title-font text-gray-900 lg:w-3/4 lg:mb-0 mb-4">
-              {item.review_content}
-            </p>
-            <div className="flex-grow"></div>
-            <div className="flex justify-between">
-              <p className="text-gray-500 text-sm">{item.reg_date}</p>
-            </div>
-          </div>
-        ))}
-      </div>
-    );
-  }
 
   return (
     <>

--- a/src/components/mypage.tsx
+++ b/src/components/mypage.tsx
@@ -1,8 +1,53 @@
 import Header from './header';
 import Footer from './footer';
 import Link from 'next/link';
+import {useEffect, useState} from 'react';
+import {useAuthState} from '../contexts/AuthContext';
+import {ReviewData} from '../lib/types';
+import {fetchReviewData} from '@/data/firestore';
 
 export default function Layout({children}: {children: React.ReactNode}) {
+  const [reviews, setReviews] = useState<ReviewData[]>([]);
+  const user = useAuthState();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const reviews = await fetchReviewData();
+
+      const filteredReviews = reviews.filter(
+        review => review.user === user.displayName,
+      );
+
+      setReviews(filteredReviews);
+    };
+
+    fetchData();
+  }, [user.displayName]);
+
+  function ReviewList({reviews}: {reviews: ReviewData[]}) {
+    return (
+      <div className="md:flex-grow mt-20">
+        {reviews.map((item, index) => (
+          <div
+            key={index}
+            className="flex w-full mx-auto mb-5 flex-wrap bg-white rounded-lg overflow-hidden shadow-md p-4"
+          >
+            <p className="title-font text-gray-900 lg:w-3/4 lg:mb-0 mb-4 font-bold">
+              {item.name}
+            </p>
+            <p className="title-font text-gray-900 lg:w-3/4 lg:mb-0 mb-4">
+              {item.contents}
+            </p>
+            <div className="flex-grow"></div>
+            <div className="flex justify-between">
+              <p className="text-gray-500 text-sm">{item.reg_date}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
   return (
     <>
       <Header />
@@ -41,15 +86,7 @@ export default function Layout({children}: {children: React.ReactNode}) {
             </div>
             <div className="-my-7">
               <div className="md:flex-grow mt-20">
-                <div className="flex w-full mx-auto mb-5 flex-wrap bg-white rounded-lg overflow-hidden shadow-md p-4">
-                  <p className="title-font text-gray-900 lg:w-3/4 lg:mb-0 mb-4">
-                    소사벌 레포츠 타운
-                  </p>
-                  <div className="flex-grow"></div>
-                  <div className="flex justify-between">
-                    <p className="text-gray-500 text-sm">2024-06-28</p>
-                  </div>
-                </div>
+                <ReviewList reviews={reviews} />
               </div>
             </div>
           </div>

--- a/src/components/mypage.tsx
+++ b/src/components/mypage.tsx
@@ -12,13 +12,20 @@ export default function Layout({children}: {children: React.ReactNode}) {
 
   useEffect(() => {
     const fetchData = async () => {
-      const reviews = await fetchReviewData();
+      try {
+        const reviews = await fetchReviewData();
 
-      const filteredReviews = reviews.filter(
-        review => review.author_user_id === user.displayName,
-      );
-
-      setReviews(filteredReviews);
+        if (reviews) {
+          const filteredReviews = reviews.filter(
+            review => review.author_user_id === user.displayName,
+          );
+          setReviews(filteredReviews);
+        } else {
+          console.error('Fetch reviews returned undefined');
+        }
+      } catch (error) {
+        console.error('Error fetching reviews:', error);
+      }
     };
 
     fetchData();

--- a/src/components/writeLayout.tsx
+++ b/src/components/writeLayout.tsx
@@ -22,8 +22,9 @@ export default function Layout({id}: {readonly id: string}) {
       id: selectedItem.id,
       name: selectedItem.FACLT_NM,
       address: selectedItem.SIGUN_NM,
-      contents: textareaData,
-      user: user.displayName ?? '',
+      content: textareaData,
+      user_id: user?.uid ?? '',
+      user_name: user?.email?.split('@')[0] ?? '',
     };
 
     addDataToFirestore(addData)

--- a/src/components/writeLayout.tsx
+++ b/src/components/writeLayout.tsx
@@ -6,11 +6,13 @@ import Loading from './loading';
 import ErrorPage from './error';
 import {addDataToFirestore} from '../data/firestore';
 import {useRouter} from 'next/navigation';
+import {useAuthState} from '../contexts/AuthContext';
 
 export default function Layout({id}: {readonly id: string}) {
   const {data, loading, error} = useData();
   const [textareaData, setTextareaData] = useState<string>('');
   const router = useRouter();
+  const user = useAuthState();
 
   const handleAddData = async () => {
     const selectedItem = data.find(item => item.id === id);
@@ -21,7 +23,7 @@ export default function Layout({id}: {readonly id: string}) {
       name: selectedItem.FACLT_NM,
       address: selectedItem.SIGUN_NM,
       contents: textareaData,
-      user: 'JM',
+      user: user.displayName ? user.displayName : '',
     };
 
     addDataToFirestore(addData)

--- a/src/components/writeLayout.tsx
+++ b/src/components/writeLayout.tsx
@@ -23,7 +23,7 @@ export default function Layout({id}: {readonly id: string}) {
       name: selectedItem.FACLT_NM,
       address: selectedItem.SIGUN_NM,
       contents: textareaData,
-      user: user.displayName ?? user.displayName,
+      user: user.displayName ?? '',
     };
 
     addDataToFirestore(addData)

--- a/src/components/writeLayout.tsx
+++ b/src/components/writeLayout.tsx
@@ -23,7 +23,7 @@ export default function Layout({id}: {readonly id: string}) {
       name: selectedItem.FACLT_NM,
       address: selectedItem.SIGUN_NM,
       contents: textareaData,
-      user: user.displayName ? user.displayName : '',
+      user: user.displayName ?? user.displayName,
     };
 
     addDataToFirestore(addData)

--- a/src/components/writeLayout.tsx
+++ b/src/components/writeLayout.tsx
@@ -23,8 +23,7 @@ export default function Layout({id}: {readonly id: string}) {
       name: selectedItem.FACLT_NM,
       address: selectedItem.SIGUN_NM,
       content: textareaData,
-      user_id: user?.uid ?? '',
-      user_name: user?.email?.split('@')[0] ?? '',
+      user_data: user,
     };
 
     addDataToFirestore(addData)

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,35 +1,25 @@
 'use client';
 import React, {createContext, useState, useEffect, useContext} from 'react';
 import {authService} from '../data/firestore';
-import {AuthContextType} from '../lib/types';
+import {User} from 'firebase/auth';
 
-const AuthStateContext = createContext<AuthContextType>({
-  userEmail: null,
-  displayName: null,
-});
+export const AuthStateContext = createContext<User | null>(null);
 
 export const AuthContextProvider = ({
   children,
 }: {
   children: React.ReactNode;
 }) => {
-  const [userEmail, setUserEmail] = useState<string | null>(null);
-  const [displayName, setDisplayName] = useState<string | null>(null);
+  const [user, setUser] = useState<User | null>(null);
 
   useEffect(() => {
-    authService.onAuthStateChanged(user => {
-      if (user) {
-        setUserEmail(user.email);
-        setDisplayName(user.email ? user.email.split('@')[0] : null);
-      } else {
-        setUserEmail(null);
-        setDisplayName(null);
-      }
+    authService.onAuthStateChanged(authuser => {
+      setUser(authuser);
     });
   }, []);
 
   return (
-    <AuthStateContext.Provider value={{userEmail, displayName}}>
+    <AuthStateContext.Provider value={user}>
       {children}
     </AuthStateContext.Provider>
   );

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React, {createContext, useState, useEffect, useContext} from 'react';
 import {authService} from '../data/firestore';
-import {User} from 'firebase/auth';
+import {User, updateProfile} from 'firebase/auth';
 
 export const AuthStateContext = createContext<User | null>(null);
 
@@ -14,9 +14,29 @@ export const AuthContextProvider = ({
 
   useEffect(() => {
     authService.onAuthStateChanged(authuser => {
+      if (authuser) {
+        const displayName = authuser.email?.split('@')[0];
+        if (displayName) {
+          updateCurrentUserProfile(displayName);
+        }
+      }
       setUser(authuser);
     });
   }, []);
+
+  const updateCurrentUserProfile = async (newDisplayName: string) => {
+    const currentUser = authService.currentUser;
+    if (currentUser) {
+      try {
+        await updateProfile(currentUser, {
+          displayName: newDisplayName,
+        });
+        console.log('프로필 업데이트 성공');
+      } catch (error) {
+        console.error('프로필 업데이트 실패:', error);
+      }
+    }
+  };
 
   return (
     <AuthStateContext.Provider value={user}>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,11 +1,7 @@
 'use client';
 import React, {createContext, useState, useEffect, useContext} from 'react';
 import {authService} from '../data/firestore';
-
-interface AuthContextType {
-  userEmail: string | null;
-  displayName: string | null;
-}
+import {AuthContextType} from '../lib/types';
 
 const AuthStateContext = createContext<AuthContextType>({
   userEmail: null,

--- a/src/data/firestore.tsx
+++ b/src/data/firestore.tsx
@@ -5,6 +5,7 @@ import {
   getDocs,
   doc,
   setDoc,
+  addDoc,
 } from 'firebase/firestore';
 import {
   getAuth,
@@ -113,19 +114,20 @@ export async function addDataToFirestore(data: AddData) {
   console.log(formattedDate);
 
   try {
-    await setDoc(doc(db, 'reviews', uuidv4()), {
-      id: data.id,
-      content: data.contents,
-      user: data.user,
-      reg_date: formattedDate,
-    });
-
-    await setDoc(doc(db, 'swimming_pools', data.id), {
-      id: data.id,
-      name: data.name,
-      address: data.address,
-      reg_date: formattedDate,
-    });
+    await Promise.all([
+      addDoc(collection(db, 'reviews'), {
+        id: data.id,
+        content: data.contents,
+        user: data.user,
+        reg_date: formattedDate,
+      }),
+      setDoc(doc(db, 'swimming_pools', data.id), {
+        id: data.id,
+        name: data.name,
+        address: data.address,
+        reg_date: formattedDate,
+      }),
+    ]);
 
     console.log('add 성공');
   } catch (error) {

--- a/src/data/firestore.tsx
+++ b/src/data/firestore.tsx
@@ -10,6 +10,8 @@ import {
   getAuth,
   createUserWithEmailAndPassword,
   signInWithEmailAndPassword,
+  setPersistence,
+  browserSessionPersistence,
 } from 'firebase/auth';
 import {v4 as uuidv4} from 'uuid';
 import {AppRouterInstance} from 'next/dist/shared/lib/app-router-context.shared-runtime';
@@ -151,6 +153,8 @@ export function signUp(
       }
     });
 }
+
+setPersistence(auth, browserSessionPersistence);
 
 export function signIn(
   email: string,

--- a/src/data/firestore.tsx
+++ b/src/data/firestore.tsx
@@ -15,6 +15,7 @@ import {
   signInWithEmailAndPassword,
   setPersistence,
   browserSessionPersistence,
+  User,
 } from 'firebase/auth';
 import {AppRouterInstance} from 'next/dist/shared/lib/app-router-context.shared-runtime';
 import {ReviewData, TotalData} from '../lib/types';
@@ -119,8 +120,7 @@ interface AddData {
   name: string;
   address: string;
   content: string;
-  user_id: string;
-  user_name: string;
+  user_data: User | null;
 }
 
 function formatDate(date: Date) {
@@ -135,14 +135,13 @@ export async function addDataToFirestore(data: AddData) {
   const today = new Date();
   const formattedDate = formatDate(today);
   console.log(formattedDate);
-
   try {
     await Promise.all([
       addDoc(collection(db, 'reviews'), {
         swimmingpool_id: data.id,
         review_content: data.content,
-        author_user_id: data.user_id,
-        author_user_name: data.user_name,
+        author_user_id: data.user_data?.uid,
+        author_user_name: data.user_data?.displayName,
         reg_date: formattedDate,
       }),
       setDoc(doc(db, 'swimming_pools', data.id), {

--- a/src/data/firestore.tsx
+++ b/src/data/firestore.tsx
@@ -62,6 +62,7 @@ export async function fetchReviewData(swimmingpool_id: string = '') {
         review_content: doc.data()['review_content'],
         swimmingpool_name: doc.data()['swimmingpool_name'],
         author_user_id: doc.data()['author_user_id'],
+        author_user_name: doc.data()['author_user_name'],
         reg_date: doc.data()['reg_date'],
       };
       reviewsData.push(reviewData);
@@ -74,6 +75,7 @@ export async function fetchReviewData(swimmingpool_id: string = '') {
         review_content: doc.data()['review_content'],
         swimmingpool_name: doc.data()['swimmingpool_name'],
         author_user_id: doc.data()['author_user_id'],
+        author_user_name: doc.data()['author_user_name'],
         reg_date: doc.data()['reg_date'],
       };
 
@@ -87,6 +89,7 @@ export async function fetchReviewData(swimmingpool_id: string = '') {
           review_content: matchingReview.review_content,
           swimmingpool_name: poolData.swimmingpool_name,
           author_user_id: matchingReview.author_user_id,
+          author_user_name: matchingReview.author_user_name,
           reg_date: matchingReview.reg_date,
         };
         totalData.push(combinedData);
@@ -102,8 +105,9 @@ interface AddData {
   id: string;
   name: string;
   address: string;
-  contents: string;
-  user: string;
+  content: string;
+  user_id: string;
+  user_name: string;
 }
 
 function formatDate(date: Date) {
@@ -123,8 +127,9 @@ export async function addDataToFirestore(data: AddData) {
     await Promise.all([
       addDoc(collection(db, 'reviews'), {
         swimmingpool_id: data.id,
-        review_content: data.contents,
-        author_user_id: data.user,
+        review_content: data.content,
+        author_user_id: data.user_id,
+        author_user_name: data.user_name,
         reg_date: formattedDate,
       }),
       setDoc(doc(db, 'swimming_pools', data.id), {

--- a/src/data/firestore.tsx
+++ b/src/data/firestore.tsx
@@ -14,7 +14,6 @@ import {
   setPersistence,
   browserSessionPersistence,
 } from 'firebase/auth';
-import {v4 as uuidv4} from 'uuid';
 import {AppRouterInstance} from 'next/dist/shared/lib/app-router-context.shared-runtime';
 import {ReviewData} from '../lib/types';
 
@@ -32,7 +31,7 @@ const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
 const auth = getAuth();
 
-export async function fetchReviewData(id: string = '') {
+export async function fetchReviewData(swimmingpool_id: string = '') {
   const reviewsData: ReviewData[] = [];
   const swimmingpoolData: ReviewData[] = [];
   const totalData: ReviewData[] = [];
@@ -47,13 +46,16 @@ export async function fetchReviewData(id: string = '') {
   }
 
   reviewsQuerySnapshot.forEach(doc => {
-    if (id === '' || doc.data()['id'] === id) {
+    if (
+      swimmingpool_id === '' ||
+      doc.data()['swimmingpool_id'] === swimmingpool_id
+    ) {
       const reviewData = {
-        id: doc.data()['id'],
-        address: doc.data()['address'],
-        contents: doc.data()['content'],
-        name: doc.data()['name'],
-        user: doc.data()['user'],
+        swimmingpool_id: doc.data()['swimmingpool_id'],
+        swimmingpool_address: doc.data()['address'],
+        review_content: doc.data()['review_content'],
+        swimmingpool_name: doc.data()['name'],
+        author_user_id: doc.data()['author_user_id'],
         reg_date: doc.data()['reg_date'],
       };
       reviewsData.push(reviewData);
@@ -62,11 +64,11 @@ export async function fetchReviewData(id: string = '') {
 
   swimmingpoolQuerySnapshot.forEach(doc => {
     const poolData = {
-      id: doc.data()['id'],
-      address: doc.data()['address'],
-      contents: doc.data()['content'],
-      name: doc.data()['name'],
-      user: doc.data()['user'],
+      swimmingpool_id: doc.data()['swimmingpool_id'],
+      swimmingpool_address: doc.data()['address'],
+      review_content: doc.data()['review_content'],
+      swimmingpool_name: doc.data()['name'],
+      author_user_id: doc.data()['author_user_id'],
       reg_date: doc.data()['reg_date'],
     };
     swimmingpoolData.push(poolData);
@@ -74,21 +76,20 @@ export async function fetchReviewData(id: string = '') {
 
   reviewsData.forEach(review => {
     const matchingPool = swimmingpoolData.find(pool => {
-      return pool.id === review.id;
+      return pool.swimmingpool_id === review.swimmingpool_id;
     });
     if (matchingPool) {
       const combinedData = {
-        id: review.id,
-        address: matchingPool.address,
-        contents: review.contents,
-        name: matchingPool.name,
-        user: review.user,
+        swimmingpool_id: review.swimmingpool_id,
+        swimmingpool_address: matchingPool.swimmingpool_address,
+        review_content: review.review_content,
+        swimmingpool_name: matchingPool.swimmingpool_name,
+        author_user_id: review.author_user_id,
         reg_date: review.reg_date,
       };
       totalData.push(combinedData);
     }
   });
-
   return totalData;
 }
 
@@ -116,15 +117,15 @@ export async function addDataToFirestore(data: AddData) {
   try {
     await Promise.all([
       addDoc(collection(db, 'reviews'), {
-        id: data.id,
-        content: data.contents,
-        user: data.user,
+        swimmingpool_id: data.id,
+        review_content: data.contents,
+        author_user_id: data.user,
         reg_date: formattedDate,
       }),
       setDoc(doc(db, 'swimming_pools', data.id), {
-        id: data.id,
-        name: data.name,
-        address: data.address,
+        swimmingpool_id: data.id,
+        swimmingpool_name: data.name,
+        swimmingpool_address: data.address,
         reg_date: formattedDate,
       }),
     ]);

--- a/src/data/firestore.tsx
+++ b/src/data/firestore.tsx
@@ -103,7 +103,7 @@ interface AddData {
   name: string;
   address: string;
   contents: string;
-  user: string;
+  user: string | null;
 }
 
 function formatDate(date: Date) {

--- a/src/data/firestore.tsx
+++ b/src/data/firestore.tsx
@@ -103,7 +103,7 @@ interface AddData {
   name: string;
   address: string;
   contents: string;
-  user: string | null;
+  user: string;
 }
 
 function formatDate(date: Date) {

--- a/src/data/firestore.tsx
+++ b/src/data/firestore.tsx
@@ -29,7 +29,7 @@ const db = getFirestore(app);
 const auth = getAuth();
 
 export async function fetchReviewData(id: string) {
-  const querySnapShot = await getDocs(collection(db, id));
+  const querySnapShot = await getDocs(collection(db, 'reviews'));
 
   if (querySnapShot.empty) {
     return [];
@@ -45,15 +45,17 @@ export async function fetchReviewData(id: string) {
   }[] = [];
 
   querySnapShot.forEach(doc => {
-    const reviewData = {
-      id: doc.data()['id'],
-      address: doc.data()['address'],
-      contents: doc.data()['contents'],
-      name: doc.data()['name'],
-      user: doc.data()['user'],
-      reg_date: doc.data()['reg_date'],
-    };
-    fetchedData.push(reviewData);
+    if (doc.data()['id'] === id) {
+      const reviewData = {
+        id: doc.data()['id'],
+        address: doc.data()['address'],
+        contents: doc.data()['content'],
+        name: doc.data()['name'],
+        user: doc.data()['user'],
+        reg_date: doc.data()['reg_date'],
+      };
+      fetchedData.push(reviewData);
+    }
   });
   return fetchedData;
 }
@@ -80,14 +82,20 @@ export async function addDataToFirestore(data: AddData) {
   console.log(formattedDate);
 
   try {
-    await setDoc(doc(db, data.id, uuidv4()), {
+    await setDoc(doc(db, 'reviews', uuidv4()), {
       id: data.id,
-      name: data.name,
-      address: data.address,
-      contents: data.contents,
+      content: data.contents,
       user: data.user,
       reg_date: formattedDate,
     });
+
+    await setDoc(doc(db, 'swimming_pools', data.id), {
+      id: data.id,
+      name: data.name,
+      address: data.address,
+      reg_date: formattedDate,
+    });
+
     console.log('add 성공');
   } catch (error) {
     console.error('add 실패: ', error);

--- a/src/lib/types.tsx
+++ b/src/lib/types.tsx
@@ -10,11 +10,11 @@ export interface PublicSwimmingPool {
 }
 
 export interface ReviewData {
-  id: string;
-  address: string;
-  contents: string;
-  name: string;
-  user: string;
+  swimmingpool_id: string;
+  swimmingpool_address: string;
+  review_content: string;
+  swimmingpool_name: string;
+  author_user_id: string;
   reg_date: string;
 }
 

--- a/src/lib/types.tsx
+++ b/src/lib/types.tsx
@@ -17,3 +17,8 @@ export interface ReviewData {
   user: string;
   reg_date: string;
 }
+
+export interface AuthContextType {
+  userEmail: string | null;
+  displayName: string | null;
+}

--- a/src/lib/types.tsx
+++ b/src/lib/types.tsx
@@ -10,11 +10,20 @@ export interface PublicSwimmingPool {
 }
 
 export interface ReviewData {
-  swimmingpool_id: string;
-  swimmingpool_address: string;
-  review_content: string;
-  swimmingpool_name: string;
   author_user_id: string;
   author_user_name: string;
   reg_date: string;
+  review_content: string;
+  review_id: string;
+  swimmingpool_id: string;
+}
+
+export interface TotalData {
+  reg_date: string;
+  swimmingpool_id: string;
+  swimmingpool_name: string;
+  author_user_id: string;
+  author_user_name: string;
+  review_content: string;
+  review_id: string;
 }

--- a/src/lib/types.tsx
+++ b/src/lib/types.tsx
@@ -15,10 +15,6 @@ export interface ReviewData {
   review_content: string;
   swimmingpool_name: string;
   author_user_id: string;
+  author_user_name: string;
   reg_date: string;
-}
-
-export interface AuthContextType {
-  userEmail: string | null;
-  displayName: string | null;
 }

--- a/src/lib/types.tsx
+++ b/src/lib/types.tsx
@@ -8,3 +8,12 @@ export interface PublicSwimmingPool {
   IRREGULR_RELYSWIMPL_LANE_CNT: string;
   [key: string]: string;
 }
+
+export interface ReviewData {
+  id: string;
+  address: string;
+  contents: string;
+  name: string;
+  user: string;
+  reg_date: string;
+}


### PR DESCRIPTION
## 변경 사항

* firestore 구조 변경, 코드 수정
  * `reviews`, `swimming_pool` collection 데이터 fetch
 
* 리뷰 작성 시 현재 로그인 한 user 데이터 전달
  * `writeLayout.tsx` 파일에서 기존 하드코딩으로 처리 했던 user를 로그인 context의 user로 변경
 
* 현재 로그인 한 유저가 방문한 수영장 조희
  * `reviews` collection의 user와 로그인 context의 user가 일치하면 데이터 반환
  * ` firestore.tsx `파일에서 `reviews`, `swimming_pool` collection fetch한 후 수영장 id가 같으면 `totalData`로 반환
  
* 로그인 인증 상태 유지
  * `setPersistence`() 메소드 이용하여 현재 session, 탭에서만 인증 상태 유지